### PR TITLE
fix : current_userが表示されない問題

### DIFF
--- a/api/app/controllers/application_controller.rb
+++ b/api/app/controllers/application_controller.rb
@@ -5,6 +5,6 @@ class ApplicationController < ActionController::API
 	end
 
 	def current_user
-			@current_user ||= User.find(session[:user_id]) if session[:user_id]
+			current_user ||= User.find(session[:user_id]) if session[:user_id]
 	end
 end

--- a/api/app/controllers/sessions_controller.rb
+++ b/api/app/controllers/sessions_controller.rb
@@ -16,7 +16,7 @@ class SessionsController < ApplicationController
 	end
 
 	def logged_in?
-		if @current_user
+		if current_user
 				render json: { logged_in: true, user: current_user }
 		else
 				render json: { logged_in: false, message: 'ユーザーが存在しません' }


### PR DESCRIPTION
ログイン認証後にcurrent_userメソッドは実行されないので、@current_userがnilになっていた。
current_userの確認をする際にcurrent_userメソッドを実行してからcurrent_userの真偽を確認するように変更した。